### PR TITLE
Calculating rollups for records where all children have been deleted

### DIFF
--- a/classes/LREngine.cls
+++ b/classes/LREngine.cls
@@ -38,6 +38,7 @@ public class LREngine {
 			3 : Group By field name
 	*/
 	static String SOQL_TEMPLATE = 'SELECT {0} FROM {1} {2} GROUP BY {3}';
+	static String COUNT_SOQL_TEMPLATE = 'SELECT Id FROM {0} WHERE Id NOT IN (SELECT {1} FROM {2})';
 	
 	/**
 		Key driver method that rolls up lookup fields based on the context. This is specially useful in Trigger context.
@@ -131,6 +132,25 @@ public class LREngine {
 				Object aggregatedDetailVal = res.get(aliasName);
 				masterObj.put(detail2MasterFldMap.get(detailFld), aggregatedDetailVal);
 			}    		
+    	}
+		
+		//since the aggregate query above won't return any results when there are zero child records, 
+    	//we need to do another query to get these records
+    	String masterTblName = ctx.master.getDescribe().getName();
+    	soql = String.format(COUNT_SOQL_TEMPLATE, new String[]{masterTblName, grpByFld, detailTblName});
+    	List<SObject> zeroChildrenRes = Database.query(soql);
+    	for (SObject obj : zeroChildrenRes) {
+    		Id masterRecId = obj.Id;
+    		Sobject masterObj = masterRecordsMap.get(masterRecId);
+    		if (masterObj == null) {
+    			System.debug(Logginglevel.WARN, 'No master record found for ID :' + masterRecId);
+				continue;
+    		}
+    		
+    		//Since none of these master records have any children, just null this rollup
+    		for (String detailFld : detail2MasterFldMap.keySet()) {
+				masterObj.put(detail2MasterFldMap.get(detailFld), null);
+			} 
     	}
     	
     	return masterRecordsMap.values();	

--- a/classes/LREngine.cls
+++ b/classes/LREngine.cls
@@ -105,9 +105,9 @@ public class LREngine {
     	String detailTblName = ctx.detail.getDescribe().getName();
     	
     	// #2 Where clause
-    	String whereClause = '';
+    	String whereClause = 'WHERE ' + ctx.lookupField.getName() + ' IN :masterIds ';
     	if (ctx.detailWhereClause != null && ctx.detailWhereClause.trim().length() > 0) {
-    		whereClause = 'WHERE ' + ctx.detailWhereClause ;
+    		whereClause = 'AND ' + ctx.detailWhereClause ;
     	}
     	
     	// #3 Group by field
@@ -134,7 +134,7 @@ public class LREngine {
 			}    		
     	}
 		
-		//since the aggregate query above won't return any results when there are zero child records, 
+	//since the aggregate query above won't return any results when there are zero child records, 
     	//we need to do another query to get these records
     	String masterTblName = ctx.master.getDescribe().getName();
     	soql = String.format(COUNT_SOQL_TEMPLATE, new String[]{masterTblName, grpByFld, detailTblName});
@@ -144,13 +144,13 @@ public class LREngine {
     		Sobject masterObj = masterRecordsMap.get(masterRecId);
     		if (masterObj == null) {
     			System.debug(Logginglevel.WARN, 'No master record found for ID :' + masterRecId);
-				continue;
+			continue;
     		}
     		
     		//Since none of these master records have any children, just null this rollup
     		for (String detailFld : detail2MasterFldMap.keySet()) {
-				masterObj.put(detail2MasterFldMap.get(detailFld), null);
-			} 
+			masterObj.put(detail2MasterFldMap.get(detailFld), null);
+		} 
     	}
     	
     	return masterRecordsMap.values();	


### PR DESCRIPTION
This is some awesome code; super helpful! I did notice that when it is used in a trigger and all of a master record's detail records are deleted, it does not calculate the rollups. This is because the aggregate query executes after the delete operation, and since it doesn't find any records at all, the AggregateResults loop never gets to it. I wrote a fix, if you're interested in merging it.