### PR TITLE
Various enhancements and fixes

### DIFF
--- a/classes/LREngine.cls
+++ b/classes/LREngine.cls
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012 tgerm.com
+Copyright (c) tgerm.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -37,7 +37,7 @@ public class LREngine {
 			2 : Optional WHERE clause filter to add
 			3 : Group By field name
 	*/
-	static String SOQL_TEMPLATE = 'SELECT {0} FROM {1} {2} GROUP BY {3}';
+	static String SOQL_TEMPLATE = 'SELECT {0} FROM {1} WHERE {3} in :masterIds {2} GROUP BY {3}';
 	
 	/**
 		Key driver method that rolls up lookup fields based on the context. This is specially useful in Trigger context.
@@ -69,6 +69,8 @@ public class LREngine {
 				because we want client or calling code to have this freedom to do some post processing and update when required.
 	*/
 	public static Sobject[] rollUp(Context ctx,  Set<Id> masterIds) {
+		// Clone this since we are about to modify it later
+		masterIds = masterIds.clone();
         // K: Id of master record
         // V: Empty sobject with ID field, this will be used for updating the masters
         Map<Id, Sobject> masterRecordsMap = new Map<Id, Sobject>(); 
@@ -79,25 +81,16 @@ public class LREngine {
     	// #0 token : SOQL projection
     	String soqlProjection = ctx.lookupField.getName();
     	// k: detail field name, v: master field name
+    	Integer exprIdx = 0;
     	Map<String, String> detail2MasterFldMap = new Map<String, String>();
-    	// k: detail field name, v: detail field small alias
-    	Map<String, String> detailFld2AliasMap = new Map<String, String>();
-    	Integer aliasCounter = 1; 
+    	Map<String, String> detail2AliasMap = new Map<String, String>();
     	for (RollupSummaryField rsf : ctx.fieldsToRoll) {
-    		/* Keeping alias short i.e. d1, d2...dn to allow more chars in SOQL to avoid SOQL char limit.
-    			It also helps in avoiding this exception when field names are more than 25 chars i.e.
-    			System.QueryException: alias is too long, maximum of 25 characters: Annualized_Recurring_Revenue__c
-    			
-    			A Sample query with new alias format will look like following
-    			SELECT AccountId, Avg(Amount) d1, Count(CloseDate) d2 FROM Opportunity  GROUP BY AccountId
-    		*/
-    		String aliasName = 'd' + aliasCounter++; 
     		// create aggreate projection with alias for easy fetching via AggregateResult class
     		// i.e. SUM(Amount) Amount
-    		soqlProjection += ', ' + rsf.operation + '(' + rsf.detail.getName() + ') ' + aliasName;
+    		String alias = 'lre'+exprIdx++; // Calculate an alias, using field name blew the 25 character limit in some cases
+    		soqlProjection += ', ' + rsf.operation + '(' + rsf.detail.getName() + ') ' + alias;
     		detail2MasterFldMap.put(rsf.detail.getName(), rsf.master.getName());
-    		// store the alias for the detail field name, it will be used for loading up later
-    		detailFld2AliasMap.put(rsf.detail.getName(), aliasName);
+    		detail2AliasMap.put(rsf.detail.getName(), alias);
     	}
 		
     	// #1 token for SOQL_TEMPLATE
@@ -106,14 +99,15 @@ public class LREngine {
     	// #2 Where clause
     	String whereClause = '';
     	if (ctx.detailWhereClause != null && ctx.detailWhereClause.trim().length() > 0) {
-    		whereClause = 'WHERE ' + ctx.detailWhereClause ;
+    		whereClause = 'AND ' + ctx.detailWhereClause ;
     	}
     	
     	// #3 Group by field
     	String grpByFld = ctx.lookupField.getName();
     	
     	String soql = String.format(SOQL_TEMPLATE, new String[]{soqlProjection, detailTblName, whereClause, grpByFld});
-    	
+        System.debug('SOQL is ' + soql);
+
     	// aggregated results 
     	List<AggregateResult> results = Database.query(soql);
     	
@@ -126,12 +120,19 @@ public class LREngine {
 			}
 			
 			for (String detailFld : detail2MasterFldMap.keySet()) {
-				// Load the alias name to fetch the value from the aggregated result
-				String aliasName = detailFld2AliasMap.get(detailFld);
-				Object aggregatedDetailVal = res.get(aliasName);
+				Object aggregatedDetailVal = res.get(detail2AliasMap.get(detailFld));
+				System.debug(LoggingLevel.INFO, 'New aggregarte value ' + aggregatedDetailVal + ' for master ' + masterRecId);
 				masterObj.put(detail2MasterFldMap.get(detailFld), aggregatedDetailVal);
-			}    		
+			} 			
+			// Remove master Id record as its been processed   	
+			masterIds.remove(masterRecId);	
     	}
+    	
+    	// Zero rollups for unprocessed master records (those with no longer any child relationships)
+    	for(Id masterRecId : masterIds)
+    		for (RollupSummaryField rsf : ctx.fieldsToRoll)
+				masterRecordsMap.get(masterRecId).put(rsf.master.getName(), 
+					rsf.isMasterTypeNumber ? 0 : null);
     	
     	return masterRecordsMap.values();	
     }

--- a/classes/LREngine.cls-meta.xml
+++ b/classes/LREngine.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>25.0</apiVersion>
+    <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/classes/TestLREngine.cls
+++ b/classes/TestLREngine.cls
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012 tgerm.com
+Copyright (c) tgerm.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -36,7 +36,20 @@ private class TestLREngine {
 		static Account acc1, acc2;
 		// common bunch of detail records for the test case
 		static Opportunity[] detailRecords;
-		
+		static Opportunity[] detailRecordsAcc1;
+		// dynamic reference to this field to avoid it being included in the package
+		static Schema.SObjectField ACCOUNT_SLA_EXPIRATION_DATE;
+		static Schema.SObjectField ACCOUNT_NUMBER_OF_LOCATIONS;		
+        static Schema.SObjectField ANNUALIZED_RECCURING_REVENUE;
+		static
+		{
+			// dynamically resolve these fields, if they are not present when the test runs, the test will return as passed to avoid failures in subscriber org when packaged
+			Map<String, Schema.SObjectField> accountFields = Schema.SObjectType.Account.fields.getMap();
+			ACCOUNT_SLA_EXPIRATION_DATE = accountFields.get('SLAExpirationDate__c');
+			ACCOUNT_NUMBER_OF_LOCATIONS = accountFields.get('NumberOfLocations__c');
+            Map<String, Schema.SObjectField> opportunityFields = Schema.SObjectType.Opportunity.fields.getMap();
+            ANNUALIZED_RECCURING_REVENUE = opportunityFields.get('Annualized_Recurring_Revenue__c');            
+		}
 		
 		/*
 		 creates the common seed data using Opportunity and Account objects. 
@@ -93,6 +106,10 @@ private class TestLREngine {
 	                                                StageName = 'test'
 	         									);
 	         detailRecords = new Opportunity[] {o1Acc1, o2Acc1, o3Acc1, o1Acc2, o2Acc2, o3Acc2};
+             if(ANNUALIZED_RECCURING_REVENUE!=null)
+                for(Opportunity detailRecord : detailRecords)
+                    detailRecord.put(ANNUALIZED_RECCURING_REVENUE, 1000);
+	         detailRecordsAcc1 = new Opportunity[] {o1Acc1, o2Acc1, o3Acc1};
 	         insert detailRecords;			
 		}		
 
@@ -101,6 +118,11 @@ private class TestLREngine {
 		Tests sum and max operations on currency and date fields
 	*/
     static testMethod void testSumAndMaxOperations() {
+    	    	
+        // Required custom field/s present?
+        if(ACCOUNT_SLA_EXPIRATION_DATE==null)
+            return;
+
     	// create seed data 
          prepareData();
          
@@ -118,12 +140,12 @@ private class TestLREngine {
                                              )); 
          ctx.add(
          		new LREngine.RollupSummaryField(
-	                                            Schema.SObjectType.Account.fields.SLAExpirationDate__c,
+	                                            ACCOUNT_SLA_EXPIRATION_DATE.getDescribe(),
 	                                            Schema.SObjectType.Opportunity.fields.CloseDate,
 	                                            LREngine.RollupOperation.Max
                                              ));                                       
                 
-         Sobject[] masters = LREngine.rollUp(ctx, detailRecords);                 
+         Sobject[] masters = LREngine.rollUp(ctx, detailRecords);  
          // 2 masters should be back  
          System.assertEquals(2, masters.size());
          
@@ -136,8 +158,8 @@ private class TestLREngine {
          System.assertEquals(450.00, reloadedAcc1.AnnualRevenue);
          System.assertEquals(900.00, reloadedAcc2.AnnualRevenue);
          
-         System.assertEquals(System.today().addMonths(1), reloadedAcc1.SLAExpirationDate__c);
-         System.assertEquals(System.today().addMonths(4), reloadedAcc2.SLAExpirationDate__c);
+         System.assertEquals(System.today().addMonths(1), reloadedAcc1.get(ACCOUNT_SLA_EXPIRATION_DATE));
+         System.assertEquals(System.today().addMonths(4), reloadedAcc2.get(ACCOUNT_SLA_EXPIRATION_DATE));
          
     }
     
@@ -146,6 +168,11 @@ private class TestLREngine {
 		Tests sum and max operations on currency and date fields
 	*/
     static testMethod void testAvgAndCountOperations() {
+    	
+        // Required custom field/s present?
+        if(ACCOUNT_NUMBER_OF_LOCATIONS==null)
+            return;
+
     	// create seed data 
          prepareData();
          
@@ -163,7 +190,7 @@ private class TestLREngine {
                                              )); 
          ctx.add(
          		new LREngine.RollupSummaryField(
-	                                            Schema.SObjectType.Account.fields.NumberofLocations__c,
+	                                            ACCOUNT_NUMBER_OF_LOCATIONS.getDescribe(),
 	                                            Schema.SObjectType.Opportunity.fields.CloseDate,
 	                                            LREngine.RollupOperation.Count
                                              ));                                       
@@ -182,8 +209,8 @@ private class TestLREngine {
          System.assertEquals(150.00, reloadedAcc1.AnnualRevenue);
          System.assertEquals(300.00, reloadedAcc2.AnnualRevenue);
          
-         System.assertEquals(3, reloadedAcc1.NumberofLocations__c);
-         System.assertEquals(3, reloadedAcc2.NumberofLocations__c);
+         System.assertEquals(3, reloadedAcc1.get(ACCOUNT_NUMBER_OF_LOCATIONS));
+         System.assertEquals(3, reloadedAcc2.get(ACCOUNT_NUMBER_OF_LOCATIONS));
     }
     
     
@@ -193,6 +220,11 @@ private class TestLREngine {
 		Here we will pass our custom criteria to filter certain records in detail, just like master detail rollup fields
 	*/
     static testMethod void testAvgAndCountOperationsWithFilter() {
+    	
+        // Required custom field/s present?
+        if(ACCOUNT_NUMBER_OF_LOCATIONS==null)
+            return;
+
     	// create seed data 
          prepareData();
          
@@ -212,7 +244,7 @@ private class TestLREngine {
                                              )); 
          ctx.add(
          		new LREngine.RollupSummaryField(
-	                                            Schema.SObjectType.Account.fields.NumberofLocations__c,
+	                                            ACCOUNT_NUMBER_OF_LOCATIONS.getDescribe(),
 	                                            Schema.SObjectType.Opportunity.fields.CloseDate,
 	                                            LREngine.RollupOperation.Count
                                              ));                                       
@@ -231,22 +263,93 @@ private class TestLREngine {
          System.assertEquals(300, reloadedAcc1.AnnualRevenue);
          System.assertEquals(350.00, reloadedAcc2.AnnualRevenue);
          
-         System.assertEquals(1, reloadedAcc1.NumberofLocations__c);
-         System.assertEquals(2, reloadedAcc2.NumberofLocations__c);
+         System.assertEquals(1, reloadedAcc1.get(ACCOUNT_NUMBER_OF_LOCATIONS));
+         System.assertEquals(2, reloadedAcc2.get(ACCOUNT_NUMBER_OF_LOCATIONS));
+    }
+
+    /**
+     * Test fix where rollup field on master records where not
+     * cleared or zerod when all children deleted
+     **/
+    static testMethod void testDeletingChildRecords()
+    {
+        // create seed data 
+        prepareData();
+
+        LREngine.Context ctx = new LREngine.Context(
+            Account.SobjectType, 
+            Opportunity.SobjectType, 
+            Schema.SObjectType.Opportunity.fields.AccountId,
+            'Amount > 200'); // filter out any opps with amount less than 200
+        ctx.add(
+            new LREngine.RollupSummaryField(
+                Schema.SObjectType.Account.fields.AnnualRevenue,
+                Schema.SObjectType.Opportunity.fields.Amount,
+                LREngine.RollupOperation.Avg)); 
+
+        Sobject[] masters = LREngine.rollUp(ctx, detailRecords);
+        Map<Id, Sobject> mastersById = new Map<Id, Sobject>(masters);
+        System.assertEquals(2, masters.size());         
+        System.assertEquals(300, ((Account)mastersById.get(acc1.id)).AnnualRevenue);
+        System.assertEquals(350.00, ((Account)mastersById.get(acc2.id)).AnnualRevenue);
+
+        // Delete all children
+        delete [select Id from Opportunity];
+
+        // Recacluate rollups again
+        masters = LREngine.rollUp(ctx, detailRecords);  
+        mastersById = new Map<Id, Sobject>(masters);               
+        System.assertEquals(0, ((Account)mastersById.get(acc1.id)).AnnualRevenue);
+        System.assertEquals(0, ((Account)mastersById.get(acc2.id)).AnnualRevenue);
     }
     
-    
-    
-     
-    /*
-    	Fixed crash when using field names longer then 25 chars.
-    	System.QueryException: alias is too long, maximum of 25 characters: Annualized_Recurring_Revenue__c
-	*/
-	/*
-	To test this please create a custom Number field by api name "Annualized_Recurring_Revenue__c" in Opportunity
- 	Then uncomment this test method
-    static testMethod void testLongDetailFields() {
+    /**
+     * Test enhancement to ensure the SOQL Aggregate only applies to child records 
+     *  related to masters referenced in incoming child records
+     **/
+    static testMethod void testConstrainedAggregateQuery()
+    {
+        // Required custom field/s present?
+        if(ACCOUNT_SLA_EXPIRATION_DATE==null)
+            return;
+
     	// create seed data 
+         prepareData();
+         
+         LREngine.Context ctx = new LREngine.Context(Account.SobjectType,  
+                                                Opportunity.SobjectType, 
+                                                Schema.SObjectType.Opportunity.fields.AccountId);         
+         ctx.add(
+                new LREngine.RollupSummaryField(
+	                                            Schema.SObjectType.Account.fields.AnnualRevenue,
+	                                            Schema.SObjectType.Opportunity.fields.Amount,
+	                                            LREngine.RollupOperation.Sum
+                                             )); 
+         ctx.add(
+         		new LREngine.RollupSummaryField(
+	                                            ACCOUNT_SLA_EXPIRATION_DATE.getDescribe(),
+	                                            Schema.SObjectType.Opportunity.fields.CloseDate,
+	                                            LREngine.RollupOperation.Max
+                                             ));                                       
+                
+         Sobject[] masters = LREngine.rollUp(ctx, detailRecordsAcc1);      
+         
+         // Only expect to have queried 3 child records related to Account 1
+         System.assertEquals(3, Limits.getQueryRows());	
+    }
+
+    /*
+        Fixed crash when using field names longer then 25 chars.
+        System.QueryException: alias is too long, maximum of 25 characters: Annualized_Recurring_Revenue__c
+        To test this please create a custom Number field by api name "Annualized_Recurring_Revenue__c" in Opportunity
+    */
+    static testMethod void testLongDetailFields() {
+
+        // Required custom field/s present?
+        if(ANNUALIZED_RECCURING_REVENUE==null)
+            return;
+
+        // create seed data 
          prepareData();
          
          LREngine.Context ctx = new LREngine.Context(Account.SobjectType, 
@@ -257,9 +360,9 @@ private class TestLREngine {
          
          ctx.add(
                 new LREngine.RollupSummaryField(
-	                                            Schema.SObjectType.Account.fields.NumberofLocations__c,
-	                                            Schema.SObjectType.Opportunity.fields.Annualized_Recurring_Revenue__c,
-	                                            LREngine.RollupOperation.Count
+                                                ACCOUNT_NUMBER_OF_LOCATIONS.getDescribe(),
+                                                ANNUALIZED_RECCURING_REVENUE.getDescribe(),
+                                                LREngine.RollupOperation.Count
                                              )); 
                 
          Sobject[] masters = LREngine.rollUp(ctx, detailRecords);                 
@@ -272,8 +375,7 @@ private class TestLREngine {
             if (so.Id == acc2.id) reloadedAcc2 = (Account)so;
          }
          
-         System.assertEquals(1, reloadedAcc1.NumberofLocations__c);
-         System.assertEquals(2, reloadedAcc2.NumberofLocations__c);
+         System.assertEquals(1, reloadedAcc1.get(ACCOUNT_NUMBER_OF_LOCATIONS));
+         System.assertEquals(2, reloadedAcc2.get(ACCOUNT_NUMBER_OF_LOCATIONS));
     }
-    */
 }

--- a/classes/TestLREngine.cls-meta.xml
+++ b/classes/TestLREngine.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>25.0</apiVersion>
+    <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>


### PR DESCRIPTION
- Constrained the SOQL_TEMPLATE by master ids (extracted from the child
  records passed in)
- Fixed field alias issue with large fields
- Fixed issue when there are no detail records, zeros or nulls the
  rollup field
- Also made changes to test code to ensure it can be packaged (packaging org must have the customer fields to ensure tests run, however they will not get packaged, tests run in subscriber will not fail if test custom fields are not present)
