### PR TITLE
Use relationship field name when accessing parent currency code

### DIFF
--- a/classes/LREngine.cls
+++ b/classes/LREngine.cls
@@ -26,167 +26,164 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 /**
-	LREngine("L"ookup "R"ollup Engine) : This class simplifies rolling up on the child records in lookup relationship.
+    LREngine("L"ookup "R"ollup Engine) : This class simplifies rolling up on the child records in lookup relationship.
 */
 public class LREngine {
-	
-	/*
-		Tempalte tokens
-			0 : Fields to project
-			1 : Object to query
-			2 : Optional WHERE clause filter to add
-			3 : Group By field name
-	*/
-	static String SOQL_TEMPLATE = 'SELECT {0} FROM {1} WHERE {3} in :masterIds {2} GROUP BY {3}';
-	
-	/*
-	Support for multi-currency orgs
-	*/
-	static String MASTERCURRENCYALIAS = 'mastercc';
-	public static String CURRENCYISOCODENAME = 'CurrencyIsoCode';
-	//http://advancedapex.com/2013/07/07/optional-features/
-	private static Boolean m_IsMultiCurrency = null;
-	public static Boolean IsMultiCurrencyOrg() {
-		if(m_IsMultiCurrency!=null) return m_IsMultiCurrency;
-		m_IsMultiCurrency = UserInfo.isMultiCurrencyOrganization();
-		return m_IsMultiCurrency;
-	}
+    
+    /*
+        Tempalte tokens
+            0 : Fields to project
+            1 : Object to query
+            2 : Optional WHERE clause filter to add
+            3 : Group By field name
+    */
+    static String SOQL_TEMPLATE = 'SELECT {0} FROM {1} WHERE {3} in :masterIds {2} GROUP BY {3}';
+    
+    /*
+    Support for multi-currency orgs
+    */
+    static String MASTERCURRENCYALIAS = 'mastercc';
+    public static String CURRENCYISOCODENAME = 'CurrencyIsoCode';
+    //http://advancedapex.com/2013/07/07/optional-features/
+    private static Boolean m_IsMultiCurrency = null;
+    public static Boolean IsMultiCurrencyOrg() {
+        if(m_IsMultiCurrency!=null) return m_IsMultiCurrency;
+        m_IsMultiCurrency = UserInfo.isMultiCurrencyOrganization();
+        return m_IsMultiCurrency;
+    }
 
-	// Currency lookup
-	static final Map<String,Decimal> currencyConversionMap = new Map<String,Decimal>();
-	private static Decimal convertCurrency(String iso, Decimal val) {
-		if(currencyConversionMap.isEmpty()){
-			String query = 'select IsoCode, ConversionRate from CurrencyType where IsActive = true';
-			for(sObject ct : Database.query(query))
-				currencyConversionMap.put((String)ct.get('IsoCode'), (Decimal)ct.get('ConversionRate'));
-		}
-		return val * currencyConversionMap.get(iso);
-	}
+    // Currency lookup
+    static final Map<String,Decimal> currencyConversionMap = new Map<String,Decimal>();
+    private static Decimal convertCurrency(String iso, Decimal val) {
+        if(currencyConversionMap.isEmpty()){
+            String query = 'select IsoCode, ConversionRate from CurrencyType where IsActive = true';
+            for(sObject ct : Database.query(query))
+                currencyConversionMap.put((String)ct.get('IsoCode'), (Decimal)ct.get('ConversionRate'));
+        }
+        return val * currencyConversionMap.get(iso);
+    }
 
-	/**
-		Key driver method that rolls up lookup fields based on the context. This is specially useful in Trigger context.
-		
-		@param ctx Context the complete context required to rollup
-		@param detailRecordsFromTrigger child/detail records which are modified/created/deleted during the Trigger 
-		@returns Array of in memory master objects. These objects are not updated back to the database
-				because we want client or calling code to have this freedom to do some post processing and update when required.
-	*/
-	public static Sobject[] rollUp(Context ctx, Sobject[] detailRecordsFromTrigger) {
-		
-		// API name of the lookup field on detail sobject
+    /**
+        Key driver method that rolls up lookup fields based on the context. This is specially useful in Trigger context.
+        
+        @param ctx Context the complete context required to rollup
+        @param detailRecordsFromTrigger child/detail records which are modified/created/deleted during the Trigger 
+        @returns Array of in memory master objects. These objects are not updated back to the database
+                because we want client or calling code to have this freedom to do some post processing and update when required.
+    */
+    public static Sobject[] rollUp(Context ctx, Sobject[] detailRecordsFromTrigger) {
+        
+        // API name of the lookup field on detail sobject
         String lookUpFieldName = ctx.lookupField.getName();
-		        
+                
         Set<Id> masterRecordIds = new Set<Id>(); 
         for (Sobject kid : detailRecordsFromTrigger) {
             masterRecordIds.add((Id)kid.get(lookUpFieldName));
         }
         return rollUp(ctx, masterRecordIds);
-	}
-	
-	/**
-		Key driver method that rolls up lookup fields based on the context. This is meant to be called from non trigger contexts like
-		scheduled/batch apex, where we want to rollup on some master record ids.
-		
-		@param Context the complete context required to rollup
-		@param masterIds Master record IDs whose child records should be rolled up. 
-		@returns Array of in memory master objects. These objects are not updated back to the database
-				because we want client or calling code to have this freedom to do some post processing and update when required.
-	*/
-	public static Sobject[] rollUp(Context ctx,  Set<Id> masterIds) {
-		// Clone this since we are about to modify it later
-		masterIds = masterIds.clone();
+    }
+    
+    /**
+        Key driver method that rolls up lookup fields based on the context. This is meant to be called from non trigger contexts like
+        scheduled/batch apex, where we want to rollup on some master record ids.
+        
+        @param Context the complete context required to rollup
+        @param masterIds Master record IDs whose child records should be rolled up. 
+        @returns Array of in memory master objects. These objects are not updated back to the database
+                because we want client or calling code to have this freedom to do some post processing and update when required.
+    */
+    public static Sobject[] rollUp(Context ctx,  Set<Id> masterIds) {
+        // Clone this since we are about to modify it later
+        masterIds = masterIds.clone();
         // K: Id of master record
         // V: Empty sobject with ID field, this will be used for updating the masters
         Map<Id, Sobject> masterRecordsMap = new Map<Id, Sobject>(); 
         for (Id mId : masterIds) {
             masterRecordsMap.put(mId, ctx.master.newSobject(mId));
         }
-		
-    	// #0 token : SOQL projection
-    	String soqlProjection = ctx.lookupField.getName();
-    	// k: detail field name, v: master field name
-    	Integer exprIdx = 0;
-		Boolean needsCurrency = false;
-    	Map<String, String> detail2MasterFldMap = new Map<String, String>();
-    	Map<String, String> detail2AliasMap = new Map<String, String>();
-        Map<String, Boolean> isFieldCurrencyMap = new Map<String, Boolean>();
-    	for (RollupSummaryField rsf : ctx.fieldsToRoll) {
-    		// create aggreate projection with alias for easy fetching via AggregateResult class
-    		// i.e. SUM(Amount) Amount
-    		String alias = 'lre'+exprIdx++; // Calculate an alias, using field name blew the 25 character limit in some cases
-    		soqlProjection += ', ' + rsf.operation + '(' + rsf.detail.getName() + ') ' + alias;
-    		detail2MasterFldMap.put(rsf.detail.getName(), rsf.master.getName());
-    		detail2AliasMap.put(rsf.detail.getName(), alias);
-			isFieldCurrencyMap.put(rsf.detail.getName(), rsf.isMasterTypeCurrency);
-			if(IsMultiCurrencyOrg() == true && needsCurrency == false && rsf.isMasterTypeCurrency){
-				needsCurrency = true;
-			}
-    	}
-		
-		// Add a field selection to get the currency from the parent record if we are depositing values into a currency field
-		if(IsMultiCurrencyOrg() == true && needsCurrency == true){
+        
+        // #0 token : SOQL projection
+        String soqlProjection = ctx.lookupField.getName();
+        // k: detail field name, v: master field name
+        Integer exprIdx = 0;
+        Boolean needsCurrency = false;
+        Map<String, RollupSummaryField> rsfByAlais = new Map<String, RollupSummaryField>();
+        for (RollupSummaryField rsf : ctx.fieldsToRoll) {
+            // create aggreate projection with alias for easy fetching via AggregateResult class
+            // i.e. SUM(Amount) Amount
+            String alias = 'lre'+exprIdx++; // Calculate an alias, using field name blew the 25 character limit in some cases
+            soqlProjection += ', ' + rsf.operation + '(' + rsf.detail.getName() + ') ' + alias;
+            rsfByAlais.put(alias, rsf);
+            if(IsMultiCurrencyOrg() == true && needsCurrency == false && rsf.isMasterTypeCurrency){
+                needsCurrency = true;
+            }
+        }
+        
+        // Add a field selection to get the currency from the parent record if we are depositing values into a currency field
+        if(IsMultiCurrencyOrg() == true && needsCurrency == true){
             String lookupRelationshipName = ctx.lookupField.getRelationshipName();
             soqlProjection += ', ' + RollupOperation.Max + '(' + lookupRelationshipName + 
-					'.' + CURRENCYISOCODENAME + ') ' + MASTERCURRENCYALIAS;
-		}
+                    '.' + CURRENCYISOCODENAME + ') ' + MASTERCURRENCYALIAS;
+        }
 
-    	// #1 token for SOQL_TEMPLATE
-    	String detailTblName = ctx.detail.getDescribe().getName();
-    	
-    	// #2 Where clause
-    	String whereClause = '';
-    	if (ctx.detailWhereClause != null && ctx.detailWhereClause.trim().length() > 0) {
-    		whereClause = 'AND ' + ctx.detailWhereClause ;
-    	}
-    	
-    	// #3 Group by field
-    	String grpByFld = ctx.lookupField.getName();
-    	
-    	String soql = String.format(SOQL_TEMPLATE, new String[]{soqlProjection, detailTblName, whereClause, grpByFld});
+        // #1 token for SOQL_TEMPLATE
+        String detailTblName = ctx.detail.getDescribe().getName();
+        
+        // #2 Where clause
+        String whereClause = '';
+        if (ctx.detailWhereClause != null && ctx.detailWhereClause.trim().length() > 0) {
+            whereClause = 'AND ' + ctx.detailWhereClause ;
+        }
+        
+        // #3 Group by field
+        String grpByFld = ctx.lookupField.getName();
+        
+        String soql = String.format(SOQL_TEMPLATE, new String[]{soqlProjection, detailTblName, whereClause, grpByFld});
         System.debug('SOQL is ' + soql);
 
-    	// aggregated results 
-    	List<AggregateResult> results = Database.query(soql);
-    	
-    	for (AggregateResult res : results){
-			Id masterRecId = (Id)res.get(grpByFld);
-			Sobject masterObj = masterRecordsMap.get(masterRecId);
-			if (masterObj == null) {
-				System.debug(Logginglevel.WARN, 'No master record found for ID :' + masterRecId);
-				continue;
-			}
-			
-			for (String detailFld : detail2MasterFldMap.keySet()) {
-				Object aggregatedDetailVal = res.get(detail2AliasMap.get(detailFld));
-				System.debug(LoggingLevel.INFO, 'New aggregarte value ' + aggregatedDetailVal + ' for master ' + masterRecId);
-				// Should also test for necessity
-				if(IsMultiCurrencyOrg() == true && isFieldCurrencyMap.get(detailFld) == true){
-					masterObj.put(detail2MasterFldMap.get(detailFld), convertCurrency((String)res.get(MASTERCURRENCYALIAS),(Decimal)aggregatedDetailVal));
-				} else {
-					masterObj.put(detail2MasterFldMap.get(detailFld), aggregatedDetailVal);
-				}
-			} 			
-			// Remove master Id record as its been processed   	
-			masterIds.remove(masterRecId);	
-    	}
-    	
-    	// Zero rollups for unprocessed master records (those with no longer any child relationships)
-    	for(Id masterRecId : masterIds)
-    		for (RollupSummaryField rsf : ctx.fieldsToRoll)
-				masterRecordsMap.get(masterRecId).put(rsf.master.getName(), 
-					rsf.isMasterTypeNumber ? 0 : null);
-    	
-    	return masterRecordsMap.values();	
+        // aggregated results 
+        List<AggregateResult> results = Database.query(soql);
+        
+        for (AggregateResult res : results){
+            Id masterRecId = (Id)res.get(grpByFld);
+            Sobject masterObj = masterRecordsMap.get(masterRecId);
+            if (masterObj == null) {
+                System.debug(Logginglevel.WARN, 'No master record found for ID :' + masterRecId);
+                continue;
+            }
+            
+            for (String alias : rsfByAlais.keySet()) {
+                RollupSummaryField rsf = rsfByAlais.get(alias);
+                Object aggregatedDetailVal = res.get(alias);
+                System.debug(LoggingLevel.INFO, 'New aggregarte value ' + aggregatedDetailVal + ' for master ' + masterRecId);
+                // Should also test for necessity
+                if(IsMultiCurrencyOrg() == true && rsf.isMasterTypeCurrency){
+                    masterObj.put(rsf.master.getName(), convertCurrency((String)res.get(MASTERCURRENCYALIAS),(Decimal)aggregatedDetailVal));
+                } else {
+                    masterObj.put(rsf.master.getName(), aggregatedDetailVal);
+                }
+            }           
+            // Remove master Id record as its been processed    
+            masterIds.remove(masterRecId);  
+        }
+        
+        // Zero rollups for unprocessed master records (those with no longer any child relationships)
+        for(Id masterRecId : masterIds)
+            for (RollupSummaryField rsf : ctx.fieldsToRoll)
+                masterRecordsMap.get(masterRecId).put(rsf.master.getName(), 
+                    rsf.isMasterTypeNumber ? 0 : null);
+        
+        return masterRecordsMap.values();   
     }
-	
-	
-	
-	
+    
+    
+    
+    
     /**
         Exception throwed if Rollup Summary field is in bad state
     */
     public class BadRollUpSummaryStateException extends Exception {}
-	
+    
    /**
        Which rollup operation you want to perform 
     */ 
@@ -195,11 +192,11 @@ public class LREngine {
     }
     
     /**
-    	Represents a "Single" roll up field, it contains
-    	- Master field where the rolled up info will be saved
-    	- Detail field that will be rolled up via any operation i.e. sum, avg etc 
-    	- Operation to perform i.e. sum, avg, count etc
-    		
+        Represents a "Single" roll up field, it contains
+        - Master field where the rolled up info will be saved
+        - Detail field that will be rolled up via any operation i.e. sum, avg etc 
+        - Operation to perform i.e. sum, avg, count etc
+            
     */
     public class RollupSummaryField {
         public Schema.Describefieldresult master;
@@ -212,7 +209,7 @@ public class LREngine {
         public boolean isDetailTypeNumber;
         public boolean isMasterTypeDateOrTime;
         public boolean isDetailTypeDateOrTime; 
-		public boolean isMasterTypeCurrency;
+        public boolean isMasterTypeCurrency;
         
         public RollupSummaryField(Schema.Describefieldresult m, 
                                          Schema.Describefieldresult d, RollupOperation op) {
@@ -226,7 +223,7 @@ public class LREngine {
             this.isDetailTypeNumber = isNumber(detail.getType());
             this.isMasterTypeDateOrTime = isDateOrTime(master.getType());
             this.isDetailTypeDateOrTime = isDateOrTime(detail.getType()); 
-			this.isMasterTypeCurrency = isCurrency(master.getType());
+            this.isMasterTypeCurrency = isCurrency(master.getType());
             // validate if field is good to work on later 
             validate();
         }   
@@ -235,9 +232,11 @@ public class LREngine {
             if (master == null || detail == null || operation == null) 
                 throw new BadRollUpSummaryStateException('All of Master/Detail Describefieldresult and RollupOperation info is mandantory');
 
-            if ( (!isMasterTypeDateOrTime && !isMasterTypeNumber) 
-                  || (!isDetailTypeDateOrTime && !isDetailTypeNumber)) {
-                    throw new BadRollUpSummaryStateException('Only Date/DateTime/Time/Numeric fields are allowed');
+            if (operation != RollupOperation.Count) {
+                if ( (!isMasterTypeDateOrTime && !isMasterTypeNumber) ||
+                     (!isDetailTypeDateOrTime && !isDetailTypeNumber)) {
+                    throw new BadRollUpSummaryStateException('Only Date/DateTime/Time/Numeric fields are allowed for Sum, Max, Min and Avg');
+                }
             }
             
             if (isMasterTypeDateOrTime && (RollupOperation.Sum == operation || RollupOperation.Avg == operation)) {
@@ -264,41 +263,41 @@ public class LREngine {
     }
     
     /**
-    	Context having all the information about the rollup to be done. 
-    	Please note : This class encapsulates many rollup summary fields with different operations.
+        Context having all the information about the rollup to be done. 
+        Please note : This class encapsulates many rollup summary fields with different operations.
     */
-	public class Context {
-	    // Master Sobject Type
-	    public Schema.Sobjecttype master;
-	    // Child/Details Sobject Type
-	    public Schema.Sobjecttype detail;
-	    // Lookup field on Child/Detail Sobject
-	    public Schema.Describefieldresult lookupField;
-	    // various fields to rollup on
-	    public List<RollupSummaryField> fieldsToRoll;
-		
-		// Where clause or filters to apply while aggregating detail records
-		public String detailWhereClause;		    
-		
-	    public Context(Schema.Sobjecttype m, Schema.Sobjecttype d, 
+    public class Context {
+        // Master Sobject Type
+        public Schema.Sobjecttype master;
+        // Child/Details Sobject Type
+        public Schema.Sobjecttype detail;
+        // Lookup field on Child/Detail Sobject
+        public Schema.Describefieldresult lookupField;
+        // various fields to rollup on
+        public List<RollupSummaryField> fieldsToRoll;
+        
+        // Where clause or filters to apply while aggregating detail records
+        public String detailWhereClause;            
+        
+        public Context(Schema.Sobjecttype m, Schema.Sobjecttype d, 
                            Schema.Describefieldresult lf) {
-			this(m, d, lf, '');                           	
+            this(m, d, lf, '');                             
         }
         
-	    public Context(Schema.Sobjecttype m, Schema.Sobjecttype d, 
+        public Context(Schema.Sobjecttype m, Schema.Sobjecttype d, 
                            Schema.Describefieldresult lf, String detailWhereClause) {
-	        this.master = m;
-	        this.detail = d;
-	        this.lookupField = lf;
-	        this.detailWhereClause = detailWhereClause;
-	        this.fieldsToRoll = new List<RollupSummaryField>();
-	    }
-	    
-	    /**
-	    	Adds new rollup summary fields to the context
-	    */
-	    public void add(RollupSummaryField fld) {
-	        this.fieldsToRoll.add(fld);
-	    }
-	}    
+            this.master = m;
+            this.detail = d;
+            this.lookupField = lf;
+            this.detailWhereClause = detailWhereClause;
+            this.fieldsToRoll = new List<RollupSummaryField>();
+        }
+        
+        /**
+            Adds new rollup summary fields to the context
+        */
+        public void add(RollupSummaryField fld) {
+            this.fieldsToRoll.add(fld);
+        }
+    }    
 }

--- a/classes/LREngine.cls
+++ b/classes/LREngine.cls
@@ -125,8 +125,8 @@ public class LREngine {
 		
 		// Add a field selection to get the currency from the parent record if we are depositing values into a currency field
 		if(IsMultiCurrencyOrg() == true && needsCurrency == true){
-			String masterTblName = ctx.master.getDescribe().getName();
-			soqlProjection += ', ' + RollupOperation.Max + '(' + masterTblName + 
+            String lookupRelationshipName = ctx.lookupField.getRelationshipName();
+            soqlProjection += ', ' + RollupOperation.Max + '(' + lookupRelationshipName + 
 					'.' + CURRENCYISOCODENAME + ') ' + MASTERCURRENCYALIAS;
 		}
 

--- a/classes/TestLREngine.cls
+++ b/classes/TestLREngine.cls
@@ -233,6 +233,55 @@ private class TestLREngine {
          System.assertEquals(3, reloadedAcc2.get(ACCOUNT_NUMBER_OF_EMPLOYEES));
     }
     
+
+    /*
+        Tests sum and max operations on currency and date fields
+    */
+    static testMethod void testAvgAndCountOperationsSameAggregateField() {
+        
+        // Required custom field/s present?
+        if(ACCOUNT_NUMBER_OF_EMPLOYEES==null)
+            return;
+
+        // create seed data 
+         prepareData();
+         
+         LREngine.Context ctx = new LREngine.Context(Account.SobjectType, 
+                                                Opportunity.SobjectType, 
+                                                Schema.SObjectType.Opportunity.fields.AccountId);
+         
+         //Select o.TotalOpportunityQuantity, o.ExpectedRevenue, o.CloseDate, o.Account.rollups__SLAExpirationDate__c, 
+         // o.Account.rollups__NumberofLocations__c, o.AccountId From Opportunity o
+         ctx.add(
+                new LREngine.RollupSummaryField(
+                                                Schema.SObjectType.Account.fields.AnnualRevenue,
+                                                Schema.SObjectType.Opportunity.fields.Amount,
+                                                LREngine.RollupOperation.Avg
+                                             )); 
+         ctx.add(
+                new LREngine.RollupSummaryField(
+                                                ACCOUNT_NUMBER_OF_EMPLOYEES.getDescribe(),
+                                                Schema.SObjectType.Opportunity.fields.Amount,
+                                                LREngine.RollupOperation.Count
+                                             ));                                       
+                
+         Sobject[] masters = LREngine.rollUp(ctx, detailRecords);                 
+         // 2 masters should be back  
+         System.assertEquals(2, masters.size());
+         
+         System.debug(masters + ' '  + acc1 + ' '  + acc2);
+         Account reloadedAcc1, reloadedAcc2;         
+         for (Sobject so : masters) { 
+            if (so.Id == acc1.id) reloadedAcc1 = (Account)so;
+            if (so.Id == acc2.id) reloadedAcc2 = (Account)so;
+         }
+         // avg would be (50 + 100 + 300) / 3 = 150
+         System.assertEquals(150.00, reloadedAcc1.AnnualRevenue);
+         System.assertEquals(300.00, reloadedAcc2.AnnualRevenue);
+         
+         System.assertEquals(3, reloadedAcc1.get(ACCOUNT_NUMBER_OF_EMPLOYEES));
+         System.assertEquals(3, reloadedAcc2.get(ACCOUNT_NUMBER_OF_EMPLOYEES));
+    }
     
     
     /*
@@ -456,4 +505,33 @@ private class TestLREngine {
 		System.assertEquals(acct1Val, (Decimal)reloadedAcc1.get('AnnualRevenue'));
 		System.assertEquals(acct2Val, (Decimal)reloadedAcc2.get('AnnualRevenue'));
 	}
+
+    static testMethod void testRollupSummaryFieldValidation() {
+
+         LREngine.Context ctx = new LREngine.Context(Account.SobjectType, 
+                                                Opportunity.SobjectType, 
+                                                Schema.SObjectType.Opportunity.fields.AccountId);
+         
+         // Valid
+         ctx.add(
+                new LREngine.RollupSummaryField(
+                                                Schema.SObjectType.Account.fields.AnnualRevenue,
+                                                Schema.SObjectType.Opportunity.fields.Id,
+                                                LREngine.RollupOperation.Count
+                                             ));                 
+
+         try {
+            // Not Valid
+            ctx.add(
+                    new LREngine.RollupSummaryField(
+                                                Schema.SObjectType.Account.fields.AnnualRevenue,
+                                                Schema.SObjectType.Opportunity.fields.Id,
+                                                LREngine.RollupOperation.Sum
+                                             ));                 
+            System.assert(false, 'Expecting an exception');
+         }
+         catch (Exception e) {
+            System.assertEquals('Only Date/DateTime/Time/Numeric fields are allowed for Sum, Max, Min and Avg', e.getMessage());
+         }
+    }    
 }


### PR DESCRIPTION
This fix resolves an issue raised in DLRS and fixed in its copy of this
class.

https://github.com/afawcett/declarative-lookup-rollup-summaries/issues/83